### PR TITLE
fix: optimizing how the dereferenced dosages are retrieved from the database

### DIFF
--- a/src/components/DosageTable.js
+++ b/src/components/DosageTable.js
@@ -11,7 +11,7 @@ import processDosages from '../services/deref';
 import axios from 'axios';
 import api from '../services/api';
 
-const dosageUri = `https://vaddb.liamgombart.com/dosages`
+const dosageUri = `https://vaddb.liamgombart.com/deref/dosages`
 
 // Main animal page with add/edit/delete handlers and data for specific animals
 const DosageTable = () => {

--- a/src/components/dosageCard.js
+++ b/src/components/dosageCard.js
@@ -4,7 +4,7 @@ import EditDosageModal from "./Modal";
 
 // Creates the table with the dosage information
 const DosageCard = (props) => { 
-    const { id, drugName, method, concentration, dose, notes } = props.dosage.deref;
+    const { id, drugName, method, concentration, dose, notes } = props.dosage.stringified;
     return (
         <Table.Row>
                 <Table.Cell>


### PR DESCRIPTION
Previously, the dereferenced dosages were using an optimized process involving hundreds of HTTP requests resulting in a slow performance.

Now the dereferenced dosages are retrieved with a single HTTP request.

A a variable name was changed from "deref" to "stringified" to reflect the fact that the frontend no longer performs the dereferencing, and is instead just stringifying the dereferenced dosages.